### PR TITLE
Clarify invader_payable interfaces

### DIFF
--- a/invader_payment/models/invader_payable.py
+++ b/invader_payment/models/invader_payable.py
@@ -6,26 +6,31 @@ from odoo import models
 class InvaderPayable(models.AbstractModel):
 
     _name = "invader.payable"
-    _description = "Provides base methods for payable models"
+    _description = "Interface for payable objects (e.g. cart, ...)"
 
     def _invader_prepare_payment_transaction_data(self, payment_mode):
         """
-        Prepare a dictionary to create a payment.transaction for the
+        Prepare a dictionary to create a ``payment.transaction`` for the
         correct amount and linked to the payable object.
-        :return:
-        """
 
-    def _invader_get_available_payment_methods(self):
+        :param payment_mode: ``account.payment.mode`` record
+        :return: dictionary suitable for ``payment.transaction`` ``create()``
         """
-        Should be implemented on payable models level.
-        :return: recordset (account.payment.method)
-        """
-        raise NotImplementedError
 
     def _invader_payment_start(self, transaction, payment_mode_id):
-        """ Called just after the transaction has been created. """
+        """
+        Called just after the transaction has been created.
+        """
         pass
 
-    def _invader_payment_success(self, transaction):
-        """ Called when the payment transaction succeeded. """
+    def _invader_payment_accepted(self, transaction):
+        """
+        Called when the payment transaction has been accepted.
+
+        This can be when the acquirer confirmed payment success, or
+        in case of bank transfer or cheque, immediatelly after
+        _invader_payment_start. This not necessarily mean that the
+        payment is confirmed, but rather to signal that the front-end tunnel
+        was successful.
+        """
         pass

--- a/invader_payment/readme/CONTRIBUTORS.rst
+++ b/invader_payment/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+Stéphane Bidoul <stephane.bidoul@acsone.eu>

--- a/invader_payment/readme/DESCRIPTION.rst
+++ b/invader_payment/readme/DESCRIPTION.rst
@@ -1,20 +1,3 @@
-
-invader.payment.service(Component):
-
-    @classmethod
-    def _invader_find_payable(target, **params)
-        # returns invader.payable
-
-    @staticmethod
-    def _invader_get_target_validator():
-        # returns a list of strings
-        # used to add in the validator
-
-
-invader.payable(AbstractModel):
-
-    def _invader_prepare_payment_transaction_data
-
-    def _invader_get_available_payment_modes...
-
-    ...
+Base module for implementing e-commerce payment methods.
+This module mostly provides an abstract component (InvaderPaymentService)
+and an abstract model (InvaderPayable).

--- a/invader_payment/services/invader_payment_service.py
+++ b/invader_payment/services/invader_payment_service.py
@@ -1,25 +1,35 @@
 # Copyright 2019 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo.addons.component.core import Component
+from odoo.addons.component.core import AbstractComponent
 
 
-class InvaderPaymentService(Component):
+class InvaderPaymentService(AbstractComponent):
 
     _name = "invader.payment.service"
     _usage = "invader.payment"
 
     def _invader_find_payable_from_target(self, target, **params):
         """
-        Find an invader.payable from a target parameter.
+        Find an invader.payable from a target parameter (e.g. current cart).
 
-        :param params:
-        :return:
+        target and params comply with the schema returned by
+        ``_invader_get_target_validator``.
         """
         raise NotImplementedError()
 
     def _invader_find_payable_from_transaction(self, transaction):
         """
-        Find then invader.payble linked to a payment.transaction.
+        Find the invader.payble linked to a payment.transaction.
+
+        This method is used to inform the payable when a transaction was
+        accepted, in situations where we are informed of payment success
+        through a webhook call from the payment acquirer.
+
+        TODO: in a future refactoring, we should eliminate
+        ``_invader_payment_accepted`` which is possible if the payable "listens"
+        for state change events on its associated ``payment.transaction``.
+        In that case ``_invader_find_payable_from_transaction`` can be
+        removed too.
         """
         raise NotImplementedError()
 
@@ -38,5 +48,8 @@ class InvaderPaymentService(Component):
         """
         This is mostly used by ShopInvader to manipulate session and
         store_cache after payment success.
+
+        TODO: this method will go away when a better mechanism for Shopinvader
+        session management is in place.
         """
         return {}

--- a/invader_payment_sips/services/payment_sips.py
+++ b/invader_payment_sips/services/payment_sips.py
@@ -209,7 +209,7 @@ class PaymentServiceSips(AbstractComponent):
             transaction.write(tx_data)
             if success:
                 transaction._set_transaction_done()
-                payable._invader_payment_success(transaction)
+                payable._invader_payment_accepted(transaction)
             else:
                 # XXX we may need to handle pending state?
                 transaction._set_transaction_cancel()

--- a/invader_payment_stripe/services/payment_stripe.py
+++ b/invader_payment_stripe/services/payment_stripe.py
@@ -161,7 +161,7 @@ class PaymentServiceStripe(AbstractComponent):
             if intent.status == "succeeded":
                 # Handle post-payment fulfillment
                 transaction._set_transaction_done()
-                payable._invader_payment_success(transaction)
+                payable._invader_payment_accepted(transaction)
             else:
                 transaction.write(
                     {"state": STRIPE_TRANSACTION_STATUSES[intent.status]}

--- a/shopinvader_payment/models/sale_order.py
+++ b/shopinvader_payment/models/sale_order.py
@@ -9,10 +9,6 @@ class SaleOrder(models.Model):
     _name = "sale.order"
     _inherit = ["sale.order", "invader.payable"]
 
-    def _invader_get_available_payment_methods(self):
-        self.ensure_one()
-        return self.shopinvader_backend_id.payment_method_ids
-
     def _invader_prepare_payment_transaction_data(self, payment_mode):
         self.ensure_one()
         vals = {
@@ -31,6 +27,6 @@ class SaleOrder(models.Model):
         vals.update(newvals)
         self.write(vals)
 
-    def _invader_payment_success(self, transaction):
+    def _invader_payment_accepted(self, transaction):
         res = self.action_confirm_cart()
         return res

--- a/shopinvader_payment/services/cart.py
+++ b/shopinvader_payment/services/cart.py
@@ -28,7 +28,7 @@ class CartService(Component):
         * The amount
         :return:
         """
-        payment_methods = sale._invader_get_available_payment_methods()
+        payment_methods = sale.shopinvader_backend_id.payment_method_ids
         selected_method = payment_methods.filtered(
             lambda m: m.payment_mode_id == sale.payment_mode_id
         )


### PR DESCRIPTION
Also, I propose here to remove _invader_get_available_payment_methods from InvaderPayable, because it returns shopinvader objects so it's a dependency violation. And I don't remember why we needed an abstract method for that.

@rousseldenis @lmignon @simahawk @sebastienbeau