### PR TITLE
[12.0] improve modularity

### DIFF
--- a/invader_payment/__manifest__.py
+++ b/invader_payment/__manifest__.py
@@ -12,6 +12,11 @@
     "application": False,
     "installable": True,
     "external_dependencies": {"python": ["cerberus", "unidecode"], "bin": []},
-    "depends": ["payment", "account_payment_mode", "component"],
+    "depends": [
+        "payment",
+        "account_payment_mode",
+        "component",
+        "component_event",
+    ],
     "data": ["views/account_payment_mode.xml"],
 }

--- a/invader_payment/models/__init__.py
+++ b/invader_payment/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account_payment_mode
 from . import invader_payable
+from . import payment_transaction

--- a/invader_payment/models/invader_payable.py
+++ b/invader_payment/models/invader_payable.py
@@ -17,8 +17,11 @@ class InvaderPayable(models.AbstractModel):
         :return: dictionary suitable for ``payment.transaction`` ``create()``
         """
 
-    def _invader_payment_start(self, transaction, payment_mode_id):
+    def _invader_set_payment_mode(self, payment_mode):
         """
-        Called just after the transaction has been created.
+        Called to set the payment_mode on the payable. The payable object can
+        be notified if the transaction process by defining an event listener.
+        see `òdoo.addons.ivader_payment.model.payment_transaction.
+        PaymentTransaction`
         """
         pass

--- a/invader_payment/models/invader_payable.py
+++ b/invader_payment/models/invader_payable.py
@@ -22,15 +22,3 @@ class InvaderPayable(models.AbstractModel):
         Called just after the transaction has been created.
         """
         pass
-
-    def _invader_payment_accepted(self, transaction):
-        """
-        Called when the payment transaction has been accepted.
-
-        This can be when the acquirer confirmed payment success, or
-        in case of bank transfer or cheque, immediatelly after
-        _invader_payment_start. This not necessarily mean that the
-        payment is confirmed, but rather to signal that the front-end tunnel
-        was successful.
-        """
-        pass

--- a/invader_payment/models/payment_transaction.py
+++ b/invader_payment/models/payment_transaction.py
@@ -1,0 +1,62 @@
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, models
+
+
+class PaymentTransaction(models.Model):
+
+    _inherit = "payment.transaction"
+
+    def _get_invader_payables(self):
+        """
+        Returns the invader_payable objects this transaction applies to
+        Each time the sate of a transaction changes an event is notified to
+        the invader_payables for the new state. The event name is formatted as
+        '_on_payment_transaction_' + state:
+
+        To be notified when one of these events occurs you must declare an
+        event listener as:
+
+        from odoo.addons.component.core import Component
+
+        class MyInvaderPayableListener(Component):
+            _name = 'my.invader.payable.event.listener'
+            _inherit = 'base.event.listener'
+            _apply_on = ['my.invader.payable']
+
+            def on_payment_transaction_draft(
+                self, invader_payable, transaction):
+                pass
+            ...
+
+        """
+        self.ensure_one()
+        return None
+
+    @api.model
+    def create(self, vals):
+        record = super(PaymentTransaction, self).create(vals)
+        record._notify_state_changed_event()
+        return record
+
+    @api.multi
+    def write(self, vals):
+        res = super(PaymentTransaction, self).write(vals)
+        if "state" in vals:
+            self._notify_state_changed_event()
+        return res
+
+    @api.multi
+    def _notify_state_changed_event(self):
+        """
+        Notify the invader_payable that the state of the transaction
+        has changed
+        """
+        for record in self:
+            payables = record._get_invader_payables()
+            if not payables:
+                continue
+            for payable in payables:
+                state = record.state
+                event_name = "on_payment_transaction_{}".format(state)
+                payable._event(event_name).notify(payable, record)

--- a/invader_payment/services/invader_payment_service.py
+++ b/invader_payment/services/invader_payment_service.py
@@ -19,23 +19,6 @@ class InvaderPaymentService(Component):
         """
         raise NotImplementedError()
 
-    def _invader_find_payable_from_transaction(self, transaction):
-        """
-        Find the invader.payble linked to a payment.transaction.
-
-        This method is used to inform the payable when a transaction was
-        accepted, in situations where we are informed of payment success
-        through a webhook call from the payment acquirer.
-
-        TODO: in a future refactoring, we should eliminate
-        ``_invader_payment_accepted`` which is possible if the payable
-        "listens" for state change events on its associated
-        ``payment.transaction``.
-        In that case ``_invader_find_payable_from_transaction`` can be
-        removed too.
-        """
-        raise NotImplementedError()
-
     def _invader_get_target_validator(self):
         """
         Return a cerberus validator schema fragment that specifies the
@@ -44,18 +27,6 @@ class InvaderPaymentService(Component):
         possibly adding other fields.
         """
         return {"target": {"type": "string", "required": True, "allowed": []}}
-
-    def _invader_get_payment_success_reponse_data(
-        self, payable, target, **params
-    ):
-        """
-        This is mostly used by ShopInvader to manipulate session and
-        store_cache after payment success.
-
-        TODO: this method will go away when a better mechanism for Shopinvader
-        session management is in place.
-        """
-        return {}
 
     def _check_acquirer(self, payment_mode, provider):
         """Check that the payment mode have the correct provider

--- a/invader_payment/services/invader_payment_service.py
+++ b/invader_payment/services/invader_payment_service.py
@@ -28,8 +28,8 @@ class InvaderPaymentService(Component):
         """
         return {"target": {"type": "string", "required": True, "allowed": []}}
 
-    def _check_acquirer(self, payment_mode, provider):
-        """Check that the payment mode have the correct provider
+    def _check_provider(self, payment_mode, provider):
+        """Check that the payment mode has the correct provider
         If the provider is not the same, raise an error
         """
         acquirer = payment_mode.payment_acquirer_id.sudo()

--- a/invader_payment_manual/services/payment_manual.py
+++ b/invader_payment_manual/services/payment_manual.py
@@ -52,8 +52,4 @@ class PaymentManual(AbstractComponent):
         )
         payable._invader_payment_start(transaction, payment_mode)
         transaction.write({"state": "pending"})
-        payable._invader_payment_accepted(transaction)
-        res = self.payment_service._invader_get_payment_success_reponse_data(
-            payable, target, **params
-        )
-        return res
+        return {}

--- a/invader_payment_manual/services/payment_manual.py
+++ b/invader_payment_manual/services/payment_manual.py
@@ -45,11 +45,11 @@ class PaymentManual(AbstractComponent):
             target, **params
         )
         payment_mode = self.env["account.payment.mode"].browse(payment_mode_id)
-        self.payment_service._check_acquirer(payment_mode, "transfer")
+        self.payment_service._check_provider(payment_mode, "transfer")
 
         transaction = transaction_obj.create(
             payable._invader_prepare_payment_transaction_data(payment_mode)
         )
-        payable._invader_payment_start(transaction, payment_mode)
+        payable._invader_set_payment_mode(payment_mode)
         transaction.write({"state": "pending"})
         return {}

--- a/invader_payment_sips/services/payment_sips.py
+++ b/invader_payment_sips/services/payment_sips.py
@@ -98,14 +98,14 @@ class PaymentServiceSips(AbstractComponent):
         )
 
         payment_mode = self.env["account.payment.mode"].browse(payment_mode_id)
-        self.payment_service._check_acquirer(payment_mode, "sips")
+        self.payment_service._check_provider(payment_mode, "sips")
 
         transaction_data = payable._invader_prepare_payment_transaction_data(
             payment_mode
         )
 
         transaction = self.env["payment.transaction"].create(transaction_data)
-        payable._invader_payment_start(transaction, payment_mode)
+        payable._invader_set_payment_mode(payment_mode)
         data = _sips_make_data(
             self._prepare_sips_data(
                 transaction, normal_return_url, automatic_response_url

--- a/invader_payment_stripe/services/payment_stripe.py
+++ b/invader_payment_stripe/services/payment_stripe.py
@@ -167,7 +167,6 @@ class PaymentServiceStripe(AbstractComponent):
             if intent.status == "succeeded":
                 # Handle post-payment fulfillment
                 transaction._set_transaction_done()
-                payable._invader_payment_accepted(transaction)
             else:
                 transaction.write(
                     {"state": STRIPE_TRANSACTION_STATUSES[intent.status]}
@@ -237,19 +236,7 @@ class PaymentServiceStripe(AbstractComponent):
                 }
             elif intent.status == "succeeded":
                 # The payment didn’t need any additional actions and completed!
-                res = {"success": True}
-                # enrich the response with additional data
-                # (necessary for ShopInvader's weird way to
-                # manipulate session data)
-                # fmt: off
-                res.update(
-                    self.payment_service
-                        ._invader_get_payment_success_reponse_data(
-                            payable, target, **params
-                        )
-                )
-                # fmt: on
-                return res
+                return {"success": True}
             elif intent.status == "canceled":
                 return {"error": _("Payment canceled.")}
             else:

--- a/invader_payment_stripe/services/payment_stripe.py
+++ b/invader_payment_stripe/services/payment_stripe.py
@@ -141,7 +141,7 @@ class PaymentServiceStripe(AbstractComponent):
         # Stripe part
         transaction = None
         payment_mode = self.env["account.payment.mode"].browse(payment_mode_id)
-        self.payment_service._check_acquirer(payment_mode, "stripe")
+        self.payment_service._check_provider(payment_mode, "stripe")
 
         try:
             if stripe_payment_method_id:
@@ -151,7 +151,7 @@ class PaymentServiceStripe(AbstractComponent):
                         payment_mode
                     )
                 )
-                payable._invader_payment_start(transaction, payment_mode)
+                payable._invader_set_payment_mode(payment_mode)
                 intent = self._prepare_stripe_intent(
                     transaction, stripe_payment_method_id
                 )

--- a/setup/invader_payment_bank_transfer/odoo/addons/invader_payment_bank_transfer
+++ b/setup/invader_payment_bank_transfer/odoo/addons/invader_payment_bank_transfer
@@ -1,0 +1,1 @@
+../../../../invader_payment_bank_transfer

--- a/setup/invader_payment_bank_transfer/setup.py
+++ b/setup/invader_payment_bank_transfer/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/invader_payment_manual/odoo/addons/invader_payment_manual
+++ b/setup/invader_payment_manual/odoo/addons/invader_payment_manual
@@ -1,0 +1,1 @@
+../../../../invader_payment_manual

--- a/setup/invader_payment_manual/setup.py
+++ b/setup/invader_payment_manual/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/shopinvader_payment_bank_transfer/odoo/addons/shopinvader_payment_bank_transfer
+++ b/setup/shopinvader_payment_bank_transfer/odoo/addons/shopinvader_payment_bank_transfer
@@ -1,0 +1,1 @@
+../../../../shopinvader_payment_bank_transfer

--- a/setup/shopinvader_payment_bank_transfer/setup.py
+++ b/setup/shopinvader_payment_bank_transfer/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/shopinvader_payment_manual/odoo/addons/shopinvader_payment_manual
+++ b/setup/shopinvader_payment_manual/odoo/addons/shopinvader_payment_manual
@@ -1,0 +1,1 @@
+../../../../shopinvader_payment_manual

--- a/setup/shopinvader_payment_manual/setup.py
+++ b/setup/shopinvader_payment_manual/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/shopinvader_quotation_payment/odoo/addons/shopinvader_quotation_payment
+++ b/setup/shopinvader_quotation_payment/odoo/addons/shopinvader_quotation_payment
@@ -1,0 +1,1 @@
+../../../../shopinvader_quotation_payment

--- a/setup/shopinvader_quotation_payment/setup.py
+++ b/setup/shopinvader_quotation_payment/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/test_invader_payment/odoo/addons/test_invader_payment
+++ b/setup/test_invader_payment/odoo/addons/test_invader_payment
@@ -1,0 +1,1 @@
+../../../../test_invader_payment

--- a/setup/test_invader_payment/setup.py
+++ b/setup/test_invader_payment/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/test_shopinvader_payment/odoo/addons/test_shopinvader_payment
+++ b/setup/test_shopinvader_payment/odoo/addons/test_shopinvader_payment
@@ -1,0 +1,1 @@
+../../../../test_shopinvader_payment

--- a/setup/test_shopinvader_payment/setup.py
+++ b/setup/test_shopinvader_payment/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopinvader_payment/__init__.py
+++ b/shopinvader_payment/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import services
+from . import components

--- a/shopinvader_payment/__manifest__.py
+++ b/shopinvader_payment/__manifest__.py
@@ -20,6 +20,7 @@
         "sale_automatic_workflow_payment_mode",
         "onchange_helper",
         "invader_payment",
+        "component_event",
     ],
     "data": [
         "views/shopinvader_menu.xml",

--- a/shopinvader_payment/components/__init__.py
+++ b/shopinvader_payment/components/__init__.py
@@ -1,0 +1,1 @@
+from . import payment_transaction_event_listerner

--- a/shopinvader_payment/components/payment_transaction_event_listerner.py
+++ b/shopinvader_payment/components/payment_transaction_event_listerner.py
@@ -1,0 +1,38 @@
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.addons.base_rest.controllers.main import _PseudoCollection
+from odoo.addons.component.core import Component
+from odoo.addons.shopinvader import shopinvader_response
+
+
+class SaleOrderPaymentTransactionEventListener(Component):
+    _name = "sale.order.payment.transaction.event.listener"
+    _inherit = "base.event.listener"
+    _apply_on = ["sale.order"]
+
+    def _confirm_and_invalidate_session(self, sale_order):
+        shopinvader_backend = sale_order.shopinvader_backend_id
+        if not shopinvader_backend:
+            return
+        sale_order.action_confirm_cart()
+        response = shopinvader_response.get()
+        response.set_session("cart_id", 0)
+        response.set_store_cache("cart", {})
+        # TODO we should not have to return the last_sale information into the
+        # response, only the id...
+        # This code is an awful hack... We should never have to call
+        # a service implementation from here. That should be the responsibility
+        # of the client to request the cart info to store into ist cache once
+        # once the cache is reset
+        collection = _PseudoCollection("shopinvader.backend", self.env)
+        work = self.work.work_on(collection=collection)
+        setattr(work, "shopinvader_backend", shopinvader_backend)
+        res = work.component(usage="cart")._to_json(sale_order)
+        response.set_store_cache("last_sale", res.get("data", {}))
+        # end of awful code ....
+
+    def on_payment_transaction_pending(self, sale_order, transaction):
+        self._confirm_and_invalidate_session(sale_order)
+
+    def on_payment_transaction_done(self, sale_order, transaction):
+        self._confirm_and_invalidate_session(sale_order)

--- a/shopinvader_payment/components/payment_transaction_event_listerner.py
+++ b/shopinvader_payment/components/payment_transaction_event_listerner.py
@@ -31,8 +31,5 @@ class SaleOrderPaymentTransactionEventListener(Component):
         response.set_store_cache("last_sale", res.get("data", {}))
         # end of awful code ....
 
-    def on_payment_transaction_pending(self, sale_order, transaction):
-        self._confirm_and_invalidate_session(sale_order)
-
     def on_payment_transaction_done(self, sale_order, transaction):
         self._confirm_and_invalidate_session(sale_order)

--- a/shopinvader_payment/models/__init__.py
+++ b/shopinvader_payment/models/__init__.py
@@ -1,3 +1,4 @@
 from . import shopinvader_backend
 from . import shopinvader_payment
 from . import sale_order
+from . import payment_transaction

--- a/shopinvader_payment/models/payment_transaction.py
+++ b/shopinvader_payment/models/payment_transaction.py
@@ -1,0 +1,15 @@
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class PaymentTransaction(models.Model):
+
+    _inherit = "payment.transaction"
+
+    def _get_invader_payables(self):
+        self.ensure_one()
+        if self.sale_order_ids:
+            return self.sale_order_ids
+        return super(PaymentTransaction, self)._get_invader_payables()

--- a/shopinvader_payment/models/sale_order.py
+++ b/shopinvader_payment/models/sale_order.py
@@ -34,7 +34,3 @@ class SaleOrder(models.Model):
         newvals = self.play_onchanges(vals, ["payment_mode_id"])
         vals.update(newvals)
         self.write(vals)
-
-    def _invader_payment_accepted(self, transaction):
-        res = self.action_confirm_cart()
-        return res

--- a/shopinvader_payment/models/sale_order.py
+++ b/shopinvader_payment/models/sale_order.py
@@ -28,9 +28,9 @@ class SaleOrder(models.Model):
         }
         return vals
 
-    def _invader_payment_start(self, transaction, payment_mode_id):
+    def _invader_set_payment_mode(self, payment_mode):
         self.ensure_one()
-        vals = {"payment_mode_id": payment_mode_id.id}
+        vals = {"payment_mode_id": payment_mode.id}
         newvals = self.play_onchanges(vals, ["payment_mode_id"])
         vals.update(newvals)
         self.write(vals)

--- a/shopinvader_payment/services/invader_payment_service.py
+++ b/shopinvader_payment/services/invader_payment_service.py
@@ -13,31 +13,7 @@ class InvaderPaymentService(Component):
             return self.component(usage="cart")._get()
         return super()._invader_find_payable_from_target(target, **params)
 
-    def _invader_find_payable_from_transaction(self, transaction):
-        if transaction.sale_order_ids:
-            return transaction.sale_order_ids
-        return super()._invader_find_payable_from_transaction(transaction)
-
     def _invader_get_target_validator(self):
         res = super()._invader_get_target_validator()
         res["target"]["allowed"].append("current_cart")
-        return res
-
-    def _invader_get_payment_success_reponse_data(
-        self, payable, target, **params
-    ):
-        res = super()._invader_get_payment_success_reponse_data(
-            payable, target, **params
-        )
-        if target == "current_cart":
-            res = self.component(usage="cart")._to_json(payable)
-            res.update(
-                {
-                    "store_cache": {
-                        "last_sale": res.get("data", {}),
-                        "cart": {},
-                    },
-                    "set_session": {"cart_id": 0},
-                }
-            )
         return res

--- a/shopinvader_payment_manual/__init__.py
+++ b/shopinvader_payment_manual/__init__.py
@@ -1,1 +1,2 @@
 from . import services
+from . import components

--- a/shopinvader_payment_manual/components/__init__.py
+++ b/shopinvader_payment_manual/components/__init__.py
@@ -1,0 +1,1 @@
+from . import payment_transaction_event_listerner

--- a/shopinvader_payment_manual/components/payment_transaction_event_listerner.py
+++ b/shopinvader_payment_manual/components/payment_transaction_event_listerner.py
@@ -1,0 +1,11 @@
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.addons.component.core import Component
+
+
+class SaleOrderPaymentTransactionEventListener(Component):
+    _inherit = "sale.order.payment.transaction.event.listener"
+
+    def on_payment_transaction_pending(self, sale_order, transaction):
+        if transaction.acquirer_id.provider == "transfer":
+            self._confirm_and_invalidate_session(sale_order)

--- a/test_invader_payment/__init__.py
+++ b/test_invader_payment/__init__.py
@@ -1,2 +1,3 @@
 from . import services
 from . import models
+from . import components

--- a/test_invader_payment/components/__init__.py
+++ b/test_invader_payment/components/__init__.py
@@ -1,0 +1,1 @@
+from . import payment_transaction_event_listerner

--- a/test_invader_payment/components/payment_transaction_event_listerner.py
+++ b/test_invader_payment/components/payment_transaction_event_listerner.py
@@ -1,0 +1,21 @@
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.addons.component.core import Component
+from odoo.addons.shopinvader import shopinvader_response
+
+
+class RestPartnerPaymentTransactionEventListener(Component):
+    _name = "res.partner.payment.transaction.event.listener"
+    _inherit = "base.event.listener"
+    _apply_on = ["res.partner"]
+
+    def _set_response_session(self, res_partner, state):
+        response = shopinvader_response.get()
+        response.set_session("payment_state", state)
+        response.set_session("partner_id", res_partner.id)
+
+    def on_payment_transaction_pending(self, res_partner, transaction):
+        self._set_response_session(res_partner, "pending")
+
+    def on_payment_transaction_done(self, res_parnter, transaction):
+        self._set_response_session(res_parnter, "done")

--- a/test_invader_payment/models/__init__.py
+++ b/test_invader_payment/models/__init__.py
@@ -1,1 +1,2 @@
 from . import res_partner
+from . import payment_transaction

--- a/test_invader_payment/models/payment_transaction.py
+++ b/test_invader_payment/models/payment_transaction.py
@@ -1,0 +1,15 @@
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class PaymentTransaction(models.Model):
+
+    _inherit = "payment.transaction"
+
+    def _get_invader_payables(self):
+        self.ensure_one()
+        if self.partner_id:
+            return self.partner_id
+        return super(PaymentTransaction, self)._get_invader_payables()

--- a/test_invader_payment/services/invader_payment_service.py
+++ b/test_invader_payment/services/invader_payment_service.py
@@ -15,11 +15,6 @@ class PaymentServiceStripe(Component):
             return self.env.ref("base.res_partner_1")
         raise NotImplementedError
 
-    def _invader_find_payable_from_transaction(self, transaction):
-        if transaction.sale_order_ids:
-            return transaction.sale_order_ids
-        return super()._invader_find_payable_from_transaction(transaction)
-
     def _invader_get_target_validator(self):
         res = super()._invader_get_target_validator()
         res["target"]["allowed"].append("demo_partner")

--- a/test_invader_payment/tests/common.py
+++ b/test_invader_payment/tests/common.py
@@ -5,9 +5,20 @@
 from odoo.addons.base_rest.controllers.main import _PseudoCollection
 from odoo.addons.component.core import WorkContext
 from odoo.addons.component.tests.common import TransactionComponentCase
+from odoo.addons.shopinvader import shopinvader_response
 
 
 class TestCommonPayment(TransactionComponentCase):
+    def setUp(self):
+        super(TestCommonPayment, self).setUp()
+        shopinvader_response.set_testmode(True)
+
+        @self.addCleanup
+        def cleanupShopinvaderResponseTestMode():
+            shopinvader_response.set_testmode(False)
+
+        self.shopinvader_response = shopinvader_response.get()
+
     def _get_service(self, usage):
         collection = _PseudoCollection("res.partner", self.env)
         work = WorkContext(

--- a/test_invader_payment/tests/test_stripe.py
+++ b/test_invader_payment/tests/test_stripe.py
@@ -24,6 +24,7 @@ class TestInvaderPayment(VCRMixin, TestCommonPayment):
         acquirer = self.env.ref("payment.payment_acquirer_stripe")
         acquirer.write({"stripe_secret_key": stripe_secret_key})
         self.service = self._get_service("payment_stripe")
+        self.demo_partner = self.env.ref("base.res_partner_1")
 
     def _get_vcr_kwargs(self, **kwargs):
         return {
@@ -50,6 +51,10 @@ class TestInvaderPayment(VCRMixin, TestCommonPayment):
             },
         )
         self.assertEqual(result, {"success": True})
+        self.assertDictEqual(
+            {"partner_id": self.demo_partner.id, "payment_state": "done"},
+            self.shopinvader_response.session,
+        )
 
     def test_confirm_payment_two_step(self):
         result = self.service.dispatch(


### PR DESCRIPTION
The idea is to let the events on payment.transaction bubble to the invader_payable so once a transaction is created the service no more need to take care of the payable...

This one requires 
 - [x] https://github.com/shopinvader/odoo-shopinvader/pull/371